### PR TITLE
fix: go module full repo name

### DIFF
--- a/checks/checks.go
+++ b/checks/checks.go
@@ -2,7 +2,7 @@ package checks
 
 import (
 	"fmt"
-	"netiscope/util"
+	"github.com/robert-kisteleki/netiscope/util"
 	"runtime"
 	"strings"
 	"sync"

--- a/checks/dns_local_resolvers.go
+++ b/checks/dns_local_resolvers.go
@@ -3,7 +3,7 @@ package checks
 import (
 	"bufio"
 	"fmt"
-	"netiscope/util"
+	"github.com/robert-kisteleki/netiscope/util"
 	"os"
 	"strings"
 	"time"

--- a/checks/dns_open_resolvers.go
+++ b/checks/dns_open_resolvers.go
@@ -2,7 +2,7 @@ package checks
 
 import (
 	"fmt"
-	"netiscope/util"
+	"github.com/robert-kisteleki/netiscope/util"
 	"strings"
 )
 

--- a/checks/dns_over_https.go
+++ b/checks/dns_over_https.go
@@ -7,7 +7,7 @@ import (
 	"io"
 	"net/http"
 
-	"netiscope/util"
+	"github.com/robert-kisteleki/netiscope/util"
 )
 
 // CheckDNSOverHTTPSProviders checks responsiveness of several DoH providers

--- a/checks/dns_resolvers.go
+++ b/checks/dns_resolvers.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"strings"
 
-	"netiscope/util"
+	"github.com/robert-kisteleki/netiscope/util"
 )
 
 // query the predefined list of names from a set of resolvers

--- a/checks/dns_root_servers.go
+++ b/checks/dns_root_servers.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 	"time"
 
-	"netiscope/util"
+	"github.com/robert-kisteleki/netiscope/util"
 )
 
 // CheckDNSRootServers checks all DNS root servers

--- a/checks/network_interfaces.go
+++ b/checks/network_interfaces.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"net"
 
-	"netiscope/util"
+	"github.com/robert-kisteleki/netiscope/util"
 )
 
 // CheckNetworkInterfaces evaulates the available network interfaces

--- a/checks/path_mtu_http.go
+++ b/checks/path_mtu_http.go
@@ -2,7 +2,7 @@ package checks
 
 import (
 	"fmt"
-	"netiscope/util"
+	"github.com/robert-kisteleki/netiscope/util"
 	"strings"
 )
 

--- a/checks/ping.go
+++ b/checks/ping.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"time"
 
-	"netiscope/util"
+	"github.com/robert-kisteleki/netiscope/util"
 
 	probing "github.com/prometheus-community/pro-bing"
 )

--- a/checks/port_filtering.go
+++ b/checks/port_filtering.go
@@ -4,7 +4,7 @@ import (
 	"bufio"
 	"fmt"
 	"net"
-	"netiscope/util"
+	"github.com/robert-kisteleki/netiscope/util"
 	"strings"
 	"time"
 )

--- a/checks/ssh_host_keys.go
+++ b/checks/ssh_host_keys.go
@@ -4,7 +4,7 @@ import (
 	"encoding/base64"
 	"fmt"
 	"net"
-	"netiscope/util"
+	"github.com/robert-kisteleki/netiscope/util"
 	"slices"
 	"strings"
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module netiscope
+module github.com/robert-kisteleki/netiscope
 
 go 1.25.0
 

--- a/gui.go
+++ b/gui.go
@@ -6,8 +6,8 @@ import (
 	"fmt"
 	"io/fs"
 	"net/http"
-	"netiscope/checks"
-	"netiscope/util"
+	"github.com/robert-kisteleki/netiscope/checks"
+	"github.com/robert-kisteleki/netiscope/util"
 	"runtime"
 	"slices"
 

--- a/netiscope.go
+++ b/netiscope.go
@@ -9,8 +9,8 @@ package main
 
 import (
 	"fmt"
-	"netiscope/checks"
-	"netiscope/util"
+	"github.com/robert-kisteleki/netiscope/checks"
+	"github.com/robert-kisteleki/netiscope/util"
 	"runtime"
 )
 


### PR DESCRIPTION
Hi,
According to [go best practice](https://go.dev/doc/modules/managing-dependencies)
`If possible, the module path should be the repository location of your source code`

So this PR change go module name to `github.com/robert-kisteleki/netiscope` and in all corresponding imports
And after that actually quickest way to run it would be just

`go run github.com/robert-kisteleki/netiscope@latest`

without cloning & building locally 